### PR TITLE
Fix time stepped range filters

### DIFF
--- a/cli/models.js
+++ b/cli/models.js
@@ -246,6 +246,9 @@ async function prepareModelRecord (db, model) {
 
     // Parse non-range filters
     for (const filter of model.filters) {
+      // Filter is time-stepped?
+      filter.timestep = hasTimesteps ? filter.timestep === true : false;
+
       if (filter.type === 'options') {
         filters = filters.concat({ ...filter });
       } else if (filter.type !== 'range') {

--- a/cli/programs/ingest.js
+++ b/cli/programs/ingest.js
@@ -76,7 +76,6 @@ module.exports = async (dirPath, command) => {
     }
 
     await db.transaction(async trx => {
-
       // Throws error if something is not correct.
       validateModelDiff(dbModel, model);
 

--- a/cli/scenarios.js
+++ b/cli/scenarios.js
@@ -73,7 +73,7 @@ async function validateModelScenario (model, filePath) {
       .fromPath(filePath, { headers: true, delimiter: ',' })
       .on('data', record => {
         // ID property always required.
-        if (!record.ID) errors.push(`Found empty value for ID at line ${line}`);
+        if (!record.ID && !record.id) { errors.push(`Found empty value for ID at line ${line}`); }
 
         // Validate intermediate FinalElecCode.
         elecCodes.forEach(c => {
@@ -188,15 +188,16 @@ async function prepareScenarioRecords (model, scenarioFilePath) {
     csv
       .fromPath(scenarioFilePath, { headers: true, delimiter: ',' })
       .on('data', record => {
-        if (record.ID.indexOf('-') > -1) {
-          record.ID = record.ID.split('-')[1];
+        let recordId = record.ID || record.id;
+        if (recordId.indexOf('-') > -1) {
+          recordId = recordId.split('-')[1];
         }
 
         // Prepare data for database.
         const entry = {
           modelId: modelId,
           scenarioId: scenarioId,
-          featureId: parseInt(record.ID),
+          featureId: parseInt(recordId),
           summary: {},
           filterValues: {}
         };


### PR DESCRIPTION
See #59.

In addition to the fix, I've added `prepareModelRecord()` step when the CLI is called with `--config-only`. It is useful to correct filters for models that were ingested before this fix.