### PR TITLE
Add people connected and total population

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -207,7 +207,11 @@ server.route({
         .select(
           db.raw(`summary->>'${'InvestmentCost' + year}' as "investmentCost"`),
           db.raw(`summary->>'${'NewCapacity' + year}' as "newCapacity"`),
-          db.raw(`summary->>'${'Pop' + year}' as "population"`)
+          db.raw(`
+            (summary->>'${'Pop' + year}')::numeric *
+            (summary->>'${'ElecStatusIn' + year}')::numeric
+            as "peopleConnected"
+          `)
         )
         .from('scenarios')
         .where('scenarioId', sid)

--- a/app/index.js
+++ b/app/index.js
@@ -245,8 +245,9 @@ server.route({
       let year = null;
 
       // Check for redis data with this query.
+      let cacheKey;
       if (process.env.NODE_ENV !== 'test') {
-        const cacheKey = JSON.stringify({ id, query });
+        cacheKey = JSON.stringify({ id, query });
         const cachedData = await rget(cacheKey);
         if (cachedData) {
           // Once the data is requested, store for a week

--- a/app/index.js
+++ b/app/index.js
@@ -207,7 +207,7 @@ server.route({
         .select(
           db.raw(`summary->>'${'InvestmentCost' + year}' as "investmentCost"`),
           db.raw(`summary->>'${'NewCapacity' + year}' as "newCapacity"`),
-          db.raw(`summary->>'${'Pop' + year}' as "electrifiedPopulation"`)
+          db.raw(`summary->>'${'Pop' + year}' as "population"`)
         )
         .from('scenarios')
         .where('scenarioId', sid)
@@ -311,7 +311,7 @@ server.route({
         electrificationTech: 'FinalElecCode' + year,
         investmentCost: 'InvestmentCost' + year,
         newCapacity: 'NewCapacity' + year,
-        electrifiedPopulation: 'Pop' + year
+        population: 'Pop' + year
       };
 
       const whereBuilder = builder => {
@@ -361,14 +361,14 @@ server.route({
         .select(
           db.raw(`
             SUM(
-              (summary->>'${summaryKeys.investmentCost}')::numeric 
+              (summary->>'${summaryKeys.investmentCost}')::numeric
             ) as "investmentCost",
             SUM(
-              (summary->>'${summaryKeys.newCapacity}')::numeric 
+              (summary->>'${summaryKeys.newCapacity}')::numeric
             ) as "newCapacity",
             SUM(
-              (summary->>'${summaryKeys.electrifiedPopulation}')::numeric 
-            ) as "electrifiedPopulation"
+              (summary->>'${summaryKeys.population}')::numeric
+            ) as "population"
           `)
         )
         .first()
@@ -377,7 +377,7 @@ server.route({
 
       summary.investmentCost = _.round(summary.investmentCost, 2);
       summary.newCapacity = _.round(summary.newCapacity, 2);
-      summary.electrifiedPopulation = _.round(summary.electrifiedPopulation, 2);
+      summary.population = _.round(summary.population, 2);
 
       // Get features
       const features = await db
@@ -394,8 +394,8 @@ server.route({
           db.raw(`summary->>'${summaryKeys.newCapacity}' as "newCapacity"`),
           db.raw(
             `summary->>'${
-              summaryKeys.electrifiedPopulation
-            }' as "electrifiedPopulation"`
+              summaryKeys.population
+            }' as "population"`
           )
         )
         .where(whereBuilder)
@@ -403,7 +403,7 @@ server.route({
         .from('scenarios');
 
       const summaryByType = {
-        electrifiedPopulation: {},
+        population: {},
         investmentCost: {},
         newCapacity: {}
       };
@@ -413,9 +413,9 @@ server.route({
       for (const f of features) {
         featureTypes[f.id] = f.electrificationTech;
 
-        summaryByType.electrifiedPopulation[f.electrificationTech] =
-          (summaryByType.electrifiedPopulation[f.electrificationTech] || 0) +
-          parseFloat(f.electrifiedPopulation);
+        summaryByType.population[f.electrificationTech] =
+          (summaryByType.population[f.electrificationTech] || 0) +
+          parseFloat(f.population);
         summaryByType.investmentCost[f.electrificationTech] =
           (summaryByType.investmentCost[f.electrificationTech] || 0) +
           parseFloat(f.investmentCost);

--- a/app/index.js
+++ b/app/index.js
@@ -249,9 +249,8 @@ server.route({
       let year = null;
 
       // Check for redis data with this query.
-      let cacheKey;
+      const cacheKey = JSON.stringify({ id, query });
       if (process.env.NODE_ENV !== 'test') {
-        cacheKey = JSON.stringify({ id, query });
         const cachedData = await rget(cacheKey);
         if (cachedData) {
           // Once the data is requested, store for a week
@@ -387,9 +386,9 @@ server.route({
       const totalPopulationQuery = db
         .select(
           db.raw(`
-            SUM((summary->>'${
-  summaryKeys.population
-}')::numeric) as "totalPopulation"
+            SUM(
+              (summary->>'${summaryKeys.population}')::numeric
+            ) as "totalPopulation"
           `)
         )
         .where('scenarioId', id)

--- a/cli/scenarios.js
+++ b/cli/scenarios.js
@@ -164,7 +164,8 @@ async function prepareScenarioRecords (model, scenarioFilePath) {
     },
     { key: 'InvestmentCost', parser: nanParser },
     { key: 'NewCapacity', parser: nanParser },
-    { key: 'Pop', parser: nanParser }
+    { key: 'Pop', parser: nanParser },
+    { key: 'ElecStatusIn', parser: nanParser }
   ];
 
   const summaryWithTimestepKeys = summaryKeys.reduce((acc, summ) => {

--- a/test/cli/csv-valid-timesteps/mw-1-0_0.csv
+++ b/test/cli/csv-valid-timesteps/mw-1-0_0.csv
@@ -1,5 +1,5 @@
-ID,FinalElecCode2030,InvestmentCost2030,NewCapacity2030,Pop2030,anotherFilter,discardedProp
-1001,1,1,1,1,1,discarded
-1002,2,10,10,10,10,discarded
-1003,3,20,20,20,20,discarded
-1004,4,,,,30,discarded
+ID,FinalElecCode2030,InvestmentCost2030,NewCapacity2030,Pop2030,ElecStatusIn2030,anotherFilter,discardedProp
+1001,1,1,1,1,0,1,discarded
+1002,2,10,10,10,1,10,discarded
+1003,3,20,20,20,1,20,discarded
+1004,4,,,,0,30,discarded

--- a/test/cli/csv-valid/mw-1-0_0.csv
+++ b/test/cli/csv-valid/mw-1-0_0.csv
@@ -1,5 +1,5 @@
-ID,FinalElecCode,InvestmentCost,NewCapacity,Pop,anotherFilter,discardedProp
-1001,1,1,1,1,1,discarded
-1002,2,10,10,10,10,discarded
-1003,3,20,20,20,20,discarded
-1004,4,,,,30,discarded
+ID,FinalElecCode,InvestmentCost,NewCapacity,Pop,ElecStatusIn,anotherFilter,discardedProp
+1001,1,1,1,1,1,1,discarded
+1002,2,10,10,10,0,10,discarded
+1003,3,20,20,20,0,20,discarded
+1004,4,,,,0,30,discarded

--- a/test/cli/test-cli-scenarios.js
+++ b/test/cli/test-cli-scenarios.js
@@ -177,7 +177,7 @@ describe('Scenario related functions', function () {
   });
 
   describe('prepareScenarioRecords', function () {
-    it.only('Prepare scenario records - no timesteps', async function () {
+    it('Prepare scenario records - no timesteps', async function () {
       const model = {
         id: 'mw-1',
         timesteps: [],

--- a/test/cli/test-cli-scenarios.js
+++ b/test/cli/test-cli-scenarios.js
@@ -177,7 +177,7 @@ describe('Scenario related functions', function () {
   });
 
   describe('prepareScenarioRecords', function () {
-    it('Prepare scenario records - no timesteps', async function () {
+    it.only('Prepare scenario records - no timesteps', async function () {
       const model = {
         id: 'mw-1',
         timesteps: [],
@@ -211,6 +211,7 @@ describe('Scenario related functions', function () {
           scenarioId: 'mw-1-0_0',
           featureId: 1001,
           summary: {
+            ElecStatusIn: 1,
             FinalElecCode: 1,
             InvestmentCost: 1,
             NewCapacity: 1,
@@ -229,6 +230,7 @@ describe('Scenario related functions', function () {
           featureId: 1002,
           summary: {
             FinalElecCode: 2,
+            ElecStatusIn: 0,
             InvestmentCost: 10,
             NewCapacity: 10,
             Pop: 10
@@ -246,6 +248,7 @@ describe('Scenario related functions', function () {
           featureId: 1003,
           summary: {
             FinalElecCode: 3,
+            ElecStatusIn: 0,
             InvestmentCost: 20,
             NewCapacity: 20,
             Pop: 20
@@ -263,6 +266,7 @@ describe('Scenario related functions', function () {
           featureId: 1004,
           summary: {
             FinalElecCode: 4,
+            ElecStatusIn: 0,
             InvestmentCost: null,
             NewCapacity: null,
             Pop: null
@@ -310,6 +314,7 @@ describe('Scenario related functions', function () {
           featureId: 1001,
           summary: {
             FinalElecCode2030: 1,
+            ElecStatusIn2030: 0,
             InvestmentCost2030: 1,
             NewCapacity2030: 1,
             Pop2030: 1
@@ -322,6 +327,7 @@ describe('Scenario related functions', function () {
           featureId: 1002,
           summary: {
             FinalElecCode2030: 2,
+            ElecStatusIn2030: 1,
             InvestmentCost2030: 10,
             NewCapacity2030: 10,
             Pop2030: 10
@@ -334,6 +340,7 @@ describe('Scenario related functions', function () {
           featureId: 1003,
           summary: {
             FinalElecCode2030: 3,
+            ElecStatusIn2030: 1,
             InvestmentCost2030: 20,
             NewCapacity2030: 20,
             Pop2030: 20
@@ -346,6 +353,7 @@ describe('Scenario related functions', function () {
           featureId: 1004,
           summary: {
             FinalElecCode2030: 4,
+            ElecStatusIn2030: 0,
             InvestmentCost2030: null,
             NewCapacity2030: null,
             Pop2030: null

--- a/test/expected-scenarios/mw-1-0_0_0-2030.json
+++ b/test/expected-scenarios/mw-1-0_0_0-2030.json
@@ -4,10 +4,11 @@
   "summary": {
     "investmentCost": 2733251.19,
     "newCapacity": 724.59,
-    "population": 100797.65
+    "totalPopulation": 100797.65,
+    "peopleConnected": 100797.65
   },
   "summaryByType": {
-    "population": {
+    "peopleConnected": {
       "1": 83548.205155,
       "3": 10698.585853284001,
       "5": 6550.857638749999

--- a/test/expected-scenarios/mw-1-0_0_0-2030.json
+++ b/test/expected-scenarios/mw-1-0_0_0-2030.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 2733251.19,
     "newCapacity": 724.59,
-    "electrifiedPopulation": 100797.65
+    "population": 100797.65
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "1": 83548.205155,
       "3": 10698.585853284001,
       "5": 6550.857638749999

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-1-5-pop.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-1-5-pop.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 352856.15,
     "newCapacity": 99.11,
-    "electrifiedPopulation": 4239.64
+    "population": 4239.64
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "1": 241.5524105,
       "5": 3998.08966615
     },

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-1-5-pop.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-1-5-pop.json
@@ -4,10 +4,11 @@
   "summary": {
     "investmentCost": 352856.15,
     "newCapacity": 99.11,
-    "population": 4239.64
+    "peopleConnected": 4239.64,
+    "totalPopulation": 100797.65
   },
   "summaryByType": {
-    "population": {
+    "peopleConnected": {
       "1": 241.5524105,
       "5": 3998.08966615
     },

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-1.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-1.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 1233350.62,
     "newCapacity": 312.1,
-    "electrifiedPopulation": 83548.21
+    "population": 83548.21
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "1": 83548.205155
     },
     "investmentCost": {

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-1.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-1.json
@@ -4,10 +4,12 @@
   "summary": {
     "investmentCost": 1233350.62,
     "newCapacity": 312.1,
-    "population": 83548.21
+    "peopleConnected": 83548.21,
+    "totalPopulation": 100797.65
+
   },
   "summaryByType": {
-    "population": {
+    "peopleConnected": {
       "1": 83548.205155
     },
     "investmentCost": {

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-2-3.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-2-3.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 938219.03,
     "newCapacity": 250.65,
-    "electrifiedPopulation": 10698.59
+    "population": 10698.59
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "3": 10698.585853284001
     },
     "investmentCost": {

--- a/test/expected-scenarios/mw-1-0_0_0-finalelecode-2-3.json
+++ b/test/expected-scenarios/mw-1-0_0_0-finalelecode-2-3.json
@@ -4,10 +4,11 @@
   "summary": {
     "investmentCost": 938219.03,
     "newCapacity": 250.65,
-    "population": 10698.59
+    "peopleConnected": 10698.59,
+    "totalPopulation": 100797.65
   },
   "summaryByType": {
-    "population": {
+    "peopleConnected": {
       "3": 10698.585853284001
     },
     "investmentCost": {

--- a/test/expected-scenarios/mw-1-0_0_0-substationdist.json
+++ b/test/expected-scenarios/mw-1-0_0_0-substationdist.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 739126.85,
     "newCapacity": 179.05,
-    "electrifiedPopulation": 24179.19
+    "population": 24179.19
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "1": 17745.692699799998,
       "3": 3935.6186482620005,
       "5": 2497.8756783400004

--- a/test/expected-scenarios/mw-1-0_0_0-substationdist.json
+++ b/test/expected-scenarios/mw-1-0_0_0-substationdist.json
@@ -4,10 +4,11 @@
   "summary": {
     "investmentCost": 739126.85,
     "newCapacity": 179.05,
-    "population": 24179.19
+    "peopleConnected": 24179.19,
+    "totalPopulation": 100797.65
   },
   "summaryByType": {
-    "population": {
+    "peopleConnected": {
       "1": 17745.692699799998,
       "3": 3935.6186482620005,
       "5": 2497.8756783400004

--- a/test/expected-scenarios/mw-1-0_0_0.json
+++ b/test/expected-scenarios/mw-1-0_0_0.json
@@ -4,10 +4,10 @@
   "summary": {
     "investmentCost": 7159142.55,
     "newCapacity": 1094.3,
-    "electrifiedPopulation": 81471.55
+    "population": 81471.55
   },
   "summaryByType": {
-    "electrifiedPopulation": {
+    "population": {
       "1": 66409.53410484397,
       "5": 15062.019021499998
     },

--- a/test/expected-scenarios/mw-1-0_0_0.json
+++ b/test/expected-scenarios/mw-1-0_0_0.json
@@ -4,11 +4,12 @@
   "summary": {
     "investmentCost": 7159142.55,
     "newCapacity": 1094.3,
-    "population": 81471.55
+    "peopleConnected": 67132.55,
+    "totalPopulation": 81471.55
   },
   "summaryByType": {
-    "population": {
-      "1": 66409.53410484397,
+    "peopleConnected": {
+      "1": 52070.5295998,
       "5": 15062.019021499998
     },
     "investmentCost": {

--- a/test/test-scenarios-features.js
+++ b/test/test-scenarios-features.js
@@ -28,7 +28,7 @@ describe('Endpoint: /scenarios/{sid}/features/{fid}', function () {
     const result = {
       investmentCost: '8932.993563',
       newCapacity: '2.470467501',
-      population: '99.6808255'
+      peopleConnected: '99.6808255'
     };
 
     return supertest(server.listener)
@@ -43,7 +43,7 @@ describe('Endpoint: /scenarios/{sid}/features/{fid}', function () {
     const result = {
       investmentCost: '8932.993563',
       newCapacity: '2.470467501',
-      population: '99.6808255'
+      peopleConnected: '99.6808255'
     };
 
     return supertest(server.listener)

--- a/test/test-scenarios-features.js
+++ b/test/test-scenarios-features.js
@@ -28,7 +28,7 @@ describe('Endpoint: /scenarios/{sid}/features/{fid}', function () {
     const result = {
       investmentCost: '8932.993563',
       newCapacity: '2.470467501',
-      electrifiedPopulation: '99.6808255'
+      population: '99.6808255'
     };
 
     return supertest(server.listener)
@@ -43,7 +43,7 @@ describe('Endpoint: /scenarios/{sid}/features/{fid}', function () {
     const result = {
       investmentCost: '8932.993563',
       newCapacity: '2.470467501',
-      electrifiedPopulation: '99.6808255'
+      population: '99.6808255'
     };
 
     return supertest(server.listener)


### PR DESCRIPTION
As discussed in https://github.com/global-electrification-platform/explorer/issues/144, the platform should display total population and people connected up to time step year. The last will change depending on applied filters, while the total population will be always the same value.

Changelog:

- Rename `population` to `totalPopulation` in summary
- Add `peopleConnected` in summary
- Disable Redis in test enviroment