### PR TITLE
Allow changing lever option value

### DIFF
--- a/cli/models.js
+++ b/cli/models.js
@@ -64,8 +64,7 @@ function getSensitiveProps (doc) {
     levers: doc.levers.map(l => ({
       id: l.id,
       options: l.options.map(o => ({
-        id: o.id,
-        value: o.value
+        id: o.id
       }))
     })),
     filters: doc.filters.map(f => ({
@@ -75,8 +74,7 @@ function getSensitiveProps (doc) {
       timestep: f.timestep === true,
       options: f.options
         ? f.options.map(o => ({
-          id: o.id,
-          value: o.value
+          id: o.id
         }))
         : null
     }))

--- a/test/cli/test-cli-models.js
+++ b/test/cli/test-cli-models.js
@@ -173,6 +173,18 @@ describe('Model related functions', function () {
 
       assert.ok(await validateModelDiff(originalModel, copy));
     });
+
+    it('Should allow changing lever option value (label)', async function () {
+      const p = path.join(__dirname, 'yml-model-valid', 'mw-1.yml');
+      const originalModel = yaml.load(await fs.readFile(p, 'utf-8'));
+
+      const copy = _.cloneDeep(originalModel);
+
+      copy.levers[1].options[1].value = 'a new option value';
+      copy.levers[0].options[1].value = 'another value';
+
+      assert.ok(await validateModelDiff(originalModel, copy));
+    });
   });
 
   describe.skip('prepareModelRecord', function () {


### PR DESCRIPTION
I've tried to update a model config that changed lever option value and got this error:

```
Sensitive properties were changed. Ingest failed.
See report below. If you need to perform these changes re-import all data.

updated properties:
{
  "levers": {
    "5": {
      "options": {
        "0": {
          "value": "Low Hanging Fruit"
        }
      }
    }
  }
}
```

The CLI should accept this kind of change as it doesn't affect interface behavior, but just the lever label. I've added a test entry to help implement the proper behavior. cc @danielfdsilva 